### PR TITLE
fix name conflict issue

### DIFF
--- a/src/utils/getModuleLocation.js
+++ b/src/utils/getModuleLocation.js
@@ -74,7 +74,7 @@ function getModuleLocation(
   if (requirePath && requirePath.length > 0) {
     modulePath = path.join(...requirePath);
   } else if (!rootNodeModule) {
-    modulePath = 'index';
+    modulePath = 'module'+mod.id; // name the file based on id to avoid conflict
   } else {
     // If a root node module, then leave it empty. The root node module's index is implied.
     // Ie, you don't need to do `foo/index`, you can just do `foo`.


### PR DESCRIPTION
I am not sure the reason of this, but while using debundle, all the modules name are resolved as "index.js" as:
```
 * 40 => index
* Reconstructing require path for module 41...
* 41 => index
* Reconstructing require path for module 42...
* 42 => index
* Reconstructing require path for module 43...
* 43 => index
* Reconstructing require path for module 44...
* 44 => index
* Reconstructing require path for module 45...
* 45 => index
* Reconstructing require path for module 46...
* 46 => index
* Reconstructing require path for module 47...
* 47 => index
* Reconstructing require path for module 48...

```

then we only have one "index.js" file been overwritten again and again.   append an id after it solves the problem.
